### PR TITLE
ci: added repository dispatch trigger for verifying backend openapi spec

### DIFF
--- a/.github/workflows/oapi_spec.yml
+++ b/.github/workflows/oapi_spec.yml
@@ -3,6 +3,8 @@ name: Verify OpenAPI Spec
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types: [ backend-openapi-spec-modified ]
 
 jobs:
   verify_no_generated:


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

This goes in conjunction with https://github.com/RHEcosystemAppEng/crda-backend/pull/30
