### PR TITLE
chore: revert "chore: remove unused telemetry key (#31)"

### DIFF
--- a/pkg/telemetry/context.go
+++ b/pkg/telemetry/context.go
@@ -22,6 +22,7 @@ const (
 	KeyClient               propertyKeyType = "client"
 	KeyTotalVulnerabilities propertyKeyType = "total-vulnerabilities"
 	KeyEcosystem            propertyKeyType = "ecosystem"
+	KeySnykTokenAssociated  propertyKeyType = "snyk-token-associated"
 	KeyJSonOutput           propertyKeyType = "json"
 	KeyVerboseOutput        propertyKeyType = "verbose"
 	KeySuccess              propertyKeyType = "success"


### PR DESCRIPTION
This reverts commit 8b67ded44ead6d5b2f871bfee53617cda8cedd98.
