### PR TITLE
chore: updated generated types for openapi spec

### DIFF
--- a/pkg/backend/api/types_generated.go
+++ b/pkg/backend/api/types_generated.go
@@ -66,10 +66,13 @@ type DependenciesSummary struct {
 
 // DependencyReport defines model for DependencyReport.
 type DependencyReport struct {
-	HighestVulnerability *Issue      `json:"highestVulnerability,omitempty"`
-	Issues               *[]Issue    `json:"issues,omitempty"`
-	Recommendation       *PackageRef `json:"recommendation,omitempty"`
-	Ref                  *PackageRef `json:"ref,omitempty"`
+	// HighestVulnerability Highest vulnerability found for this dependency
+	HighestVulnerability *Issue   `json:"highestVulnerability,omitempty"`
+	Issues               *[]Issue `json:"issues,omitempty"`
+
+	// Recommendation Trusted Content recommendation that is not related to any security vulnerability
+	Recommendation *PackageRef `json:"recommendation,omitempty"`
+	Ref            *PackageRef `json:"ref,omitempty"`
 
 	// Remediations Trusted Content remediation related to identified security vulnerabilities
 	Remediations *map[string]Remediation       `json:"remediations,omitempty"`


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

Changed caused by https://github.com/RHEcosystemAppEng/crda-backend/pull/44.
